### PR TITLE
Optimized ffmpeg to reduce stream latency

### DIFF
--- a/contrib/setup.sh
+++ b/contrib/setup.sh
@@ -51,7 +51,7 @@ if [ ! -d ~/mediamtx ]; then
     if ! grep -q 'cam1:' ~/mediamtx/mediamtx.yml; then
         cat << EOF >> ~/mediamtx/mediamtx.yml
   cam1:
-    runOnInit: bash -c 'libcamera-vid -t 0 --width 1280 --height 720 --inline --listen -o - | ffmpeg -i /dev/stdin -c:v libx264 -tune zerolatency -f rtsp rtsp://localhost:8554/cam1'
+    runOnInit: bash -c 'libcamera-vid -t 0 --width 1280 --height 720 --inline --listen -o - | ffmpeg -fflags +genpts -i /dev/stdin -c:v libx264 -preset ultrafast -tune zerolatency -profile:v baseline -x264-params "nal-hrd=cbr:force-cfr=1" -b:v 2M -maxrate 2M -bufsize 4M -g 60 -keyint_min 60 -sc_threshold 0 -f rtsp -rtsp_transport tcp rtsp://localhost:8554/cam1'
     runOnInitRestart: yes
 EOF
     fi


### PR DESCRIPTION
-fflags +genpts: Generates presentation timestamps, which can help with stream stability.
-preset ultrafast -tune zerolatency: These settings prioritize low latency.
-profile:v baseline: Uses the baseline profile for better compatibility with WebRTC.
-x264-params "nal-hrd=cbr:force-cfr=1": Enables constant bitrate mode and forces constant frame rate, which can help with stream stability.
-b:v 2M -maxrate 2M -bufsize 4M: Sets a target bitrate of 2 Mbps, with a buffer that allows for some flexibility. Adjust these values based on your network capacity.
-g 60 -keyint_min 60: Sets the GOP (Group of Pictures) size to 60 frames, which means a keyframe every 2 seconds at 30 fps. This can help with stream recovery if packets are lost.
-sc_threshold 0: Disables scene change detection, which can sometimes cause issues in live streams.
-f rtsp -rtsp_transport tcp: Forces RTSP over TCP, which is generally more reliable than UDP for RTSP.