### PR TITLE
Fix Gripper instance (incorrect spec in mavlink docs)

### DIFF
--- a/src/frontend/src/components/Stats.svelte
+++ b/src/frontend/src/components/Stats.svelte
@@ -282,7 +282,7 @@
         confirmation: true,
         notification: false,
         onConfirm: async () => {
-          await sendMavlinkCommand('DO_GRIPPER' , `${[1, 0]}`); // param2 - 0: release, 1: grip
+          await sendMavlinkCommand('DO_GRIPPER' , `${[0, 0]}`); // param2 - 0: release, 1: grip
           modal.$destroy();
         },
       }

--- a/src/frontend/src/lib/server/mavlink.ts
+++ b/src/frontend/src/lib/server/mavlink.ts
@@ -83,8 +83,6 @@ function setupPacketReader(): void {
             logs.push(logEntry);
             newLogs.push(logEntry);
             if (logEntry.includes('_ACK') && !logEntry.includes('"command":512')) console.log(logEntry);
-            if (logEntry.includes('PARAM_EXT_ACK')) console.log(logEntry);
-            if (logEntry.includes('PARAM_ACK_TRANSACTION')) console.log(logEntry);
         }
     });
 }


### PR DESCRIPTION
- Gripper instances are 0 indexed, not 1 indexed
- See https://github.com/ArduPilot/ardupilot/issues/3374